### PR TITLE
Switch to OAuth API and improve usage widget

### DIFF
--- a/src/main/kotlin/com/example/anthropic/api/AnthropicApiService.kt
+++ b/src/main/kotlin/com/example/anthropic/api/AnthropicApiService.kt
@@ -2,38 +2,91 @@ package com.example.anthropic.api
 
 import com.example.anthropic.api.models.UsageData
 import com.example.anthropic.api.models.toUsageData
+import com.intellij.openapi.diagnostic.logger
 
 /**
- * Service for fetching usage data from personal claude.ai accounts
+ * Service for fetching usage data from Claude OAuth API.
+ * Uses api.anthropic.com/api/oauth/usage endpoint.
  */
 class AnthropicApiService {
-    private var client: ClaudePersonalApiClient? = null
+    private val log = logger<AnthropicApiService>()
+    private val credentialDiscovery = ClaudeCredentialDiscovery()
 
-    fun initialize(sessionKey: String, organizationId: String) {
-        this.client = ClaudePersonalApiClient(sessionKey, organizationId)
+    private var oauthClient: ClaudeOAuthApiClient? = null
+    private var isAutoDiscovered: Boolean = false
+
+    /**
+     * Initialize with manual OAuth token.
+     */
+    fun initializeWithToken(accessToken: String) {
+        log.info("Initializing with manual OAuth token")
+        this.oauthClient = ClaudeOAuthApiClient(accessToken)
+        this.isAutoDiscovered = false
     }
 
-    fun isInitialized(): Boolean = client != null
+    /**
+     * Initialize with auto-discovered credentials.
+     * Returns true if credentials were found, false otherwise.
+     */
+    fun initializeWithAutoDiscovery(): Boolean {
+        log.info("Attempting to auto-discover OAuth credentials")
+        val credentials = credentialDiscovery.discoverAccessToken()
+
+        if (credentials == null) {
+            log.info("No OAuth credentials found")
+            return false
+        }
+
+        if (credentials.isExpired()) {
+            log.warn("Discovered credentials are expired, but will try anyway")
+        }
+
+        log.info("Found OAuth credentials from ${credentials.source}")
+        this.oauthClient = ClaudeOAuthApiClient(credentials.accessToken)
+        this.isAutoDiscovered = true
+        return true
+    }
+
+    fun isInitialized(): Boolean = oauthClient != null
+
+    fun isUsingAutoDiscovery(): Boolean = isAutoDiscovered
+
+    /**
+     * Check if OAuth credentials can be auto-discovered.
+     */
+    fun canAutoDiscoverCredentials(): Boolean {
+        return credentialDiscovery.hasCredentials()
+    }
+
+    /**
+     * Get information about discovered credentials (for UI display).
+     */
+    fun getDiscoveredCredentialsInfo(): String? {
+        val credentials = credentialDiscovery.discoverAccessToken() ?: return null
+        val sourceStr = when (credentials.source) {
+            CredentialSource.FILE -> "~/.claude/.credentials.json"
+            CredentialSource.KEYCHAIN -> "macOS Keychain"
+            CredentialSource.MANUAL -> "manual"
+        }
+        val expiredStr = if (credentials.isExpired()) " (expired)" else ""
+        return "Found in $sourceStr$expiredStr"
+    }
 
     suspend fun fetchCurrentUsage(): Result<UsageData> {
-        val currentClient = client
+        val client = oauthClient
             ?: return Result.failure(IllegalStateException(
-                "Client not initialized. Please configure your sessionKey and organization ID in settings."
+                "Client not initialized. Please configure your credentials in settings."
             ))
 
-        return currentClient.getPersonalUsage()
+        return client.getUsage()
             .map { response -> response.toUsageData() }
     }
 
     suspend fun testConnection(): Result<Boolean> {
-        val currentClient = client
-            ?: return Result.failure(IllegalStateException("Client not initialized"))
-
-        return currentClient.getPersonalUsage()
-            .map { true }
+        return fetchCurrentUsage().map { true }
     }
 
     fun dispose() {
-        client = null
+        oauthClient = null
     }
 }

--- a/src/main/kotlin/com/example/anthropic/api/ClaudeCredentialDiscovery.kt
+++ b/src/main/kotlin/com/example/anthropic/api/ClaudeCredentialDiscovery.kt
@@ -1,0 +1,185 @@
+package com.example.anthropic.api
+
+import com.google.gson.Gson
+import com.google.gson.annotations.SerializedName
+import com.intellij.openapi.diagnostic.logger
+import java.io.File
+
+/**
+ * Discovers OAuth credentials from Claude Code installations.
+ *
+ * Credential sources (in priority order):
+ * 1. File-based credentials (~/.claude/.credentials.json)
+ * 2. macOS Keychain (Claude Code 2.x) - future implementation
+ */
+class ClaudeCredentialDiscovery {
+    private val log = logger<ClaudeCredentialDiscovery>()
+    private val gson = Gson()
+
+    /**
+     * Attempts to discover OAuth access token from Claude Code credential stores.
+     * Returns null if no valid credentials found.
+     *
+     * Discovery order (same as claude-hud):
+     * 1. macOS Keychain (Claude Code 2.x) - primary source
+     * 2. File-based (~/.claude/.credentials.json) - fallback
+     */
+    fun discoverAccessToken(): DiscoveredCredentials? {
+        // Try macOS Keychain first (only on macOS) - this is the primary source
+        if (isMacOS()) {
+            val keychainCredentials = tryMacOSKeychain()
+            if (keychainCredentials != null) {
+                log.info("Found credentials in macOS Keychain")
+                return keychainCredentials
+            }
+        }
+
+        // Fall back to file-based credentials
+        val fileCredentials = tryFileBasedCredentials()
+        if (fileCredentials != null) {
+            log.info("Found credentials in ~/.claude/.credentials.json")
+            return fileCredentials
+        }
+
+        log.info("No Claude Code credentials found")
+        return null
+    }
+
+    /**
+     * Try to read credentials from ~/.claude/.credentials.json
+     */
+    private fun tryFileBasedCredentials(): DiscoveredCredentials? {
+        return try {
+            val homeDir = System.getProperty("user.home")
+            val credentialsFile = File(homeDir, ".claude/.credentials.json")
+
+            if (!credentialsFile.exists()) {
+                log.debug("Credentials file not found: ${credentialsFile.absolutePath}")
+                return null
+            }
+
+            val content = credentialsFile.readText()
+            val credentials = gson.fromJson(content, ClaudeCredentialsFile::class.java)
+
+            // Check for OAuth token
+            val accessToken = credentials.claudeAiOauth?.accessToken
+            if (accessToken.isNullOrBlank()) {
+                log.debug("No access token found in credentials file")
+                return null
+            }
+
+            // Check if token is expired
+            val expiresAt = credentials.claudeAiOauth.expiresAt
+            if (expiresAt != null && expiresAt < System.currentTimeMillis()) {
+                log.warn("Access token is expired (expired at: $expiresAt)")
+                // Still return it - the API will handle refresh or error
+            }
+
+            DiscoveredCredentials(
+                accessToken = accessToken,
+                source = CredentialSource.FILE,
+                expiresAt = expiresAt
+            )
+        } catch (e: Exception) {
+            log.warn("Failed to read credentials file: ${e.message}")
+            null
+        }
+    }
+
+    /**
+     * Try to read credentials from macOS Keychain.
+     * Uses security command to access Claude Code's keychain entry.
+     * Service name: 'Claude Code-credentials'
+     */
+    private fun tryMacOSKeychain(): DiscoveredCredentials? {
+        return try {
+            val process = ProcessBuilder(
+                "/usr/bin/security",
+                "find-generic-password",
+                "-s", "Claude Code-credentials",
+                "-w"
+            )
+                .redirectErrorStream(false)
+                .start()
+
+            val exitCode = process.waitFor()
+            if (exitCode != 0) {
+                log.debug("Keychain entry not found or access denied")
+                return null
+            }
+
+            val password = process.inputStream.bufferedReader().readText().trim()
+            if (password.isBlank()) {
+                return null
+            }
+
+            // Parse the keychain entry (JSON format with claudeAiOauth wrapper)
+            val keychainData = gson.fromJson(password, ClaudeCredentialsFile::class.java)
+            val oauthData = keychainData.claudeAiOauth
+
+            if (oauthData?.accessToken.isNullOrBlank()) {
+                log.debug("No access token in keychain entry")
+                return null
+            }
+
+            DiscoveredCredentials(
+                accessToken = oauthData!!.accessToken!!,
+                source = CredentialSource.KEYCHAIN,
+                expiresAt = oauthData.expiresAt
+            )
+        } catch (e: Exception) {
+            log.debug("Failed to read from macOS Keychain: ${e.message}")
+            null
+        }
+    }
+
+    private fun isMacOS(): Boolean {
+        return System.getProperty("os.name").lowercase().contains("mac")
+    }
+
+    /**
+     * Checks if Claude Code credentials are available.
+     */
+    fun hasCredentials(): Boolean {
+        return discoverAccessToken() != null
+    }
+}
+
+/**
+ * Discovered OAuth credentials.
+ */
+data class DiscoveredCredentials(
+    val accessToken: String,
+    val source: CredentialSource,
+    val expiresAt: Long? = null
+) {
+    fun isExpired(): Boolean {
+        return expiresAt != null && expiresAt < System.currentTimeMillis()
+    }
+}
+
+enum class CredentialSource {
+    FILE,
+    KEYCHAIN,
+    MANUAL
+}
+
+/**
+ * Structure of ~/.claude/.credentials.json
+ */
+data class ClaudeCredentialsFile(
+    @SerializedName("claudeAiOauth")
+    val claudeAiOauth: OAuthTokenData?
+)
+
+data class OAuthTokenData(
+    @SerializedName("accessToken")
+    val accessToken: String?,
+    @SerializedName("refreshToken")
+    val refreshToken: String?,
+    @SerializedName("expiresAt")
+    val expiresAt: Long?,
+    @SerializedName("scopes")
+    val scopes: List<String>?
+)
+

--- a/src/main/kotlin/com/example/anthropic/api/ClaudeOAuthApiClient.kt
+++ b/src/main/kotlin/com/example/anthropic/api/ClaudeOAuthApiClient.kt
@@ -11,17 +11,25 @@ import okhttp3.logging.HttpLoggingInterceptor
 import java.util.concurrent.TimeUnit
 
 /**
- * API client for personal claude.ai accounts (unofficial API)
+ * API client for Claude OAuth API.
+ * Uses the official OAuth endpoint: api.anthropic.com/api/oauth/usage
  *
- * WARNING: This uses unofficial/undocumented API endpoints that may change at any time.
- * Use at your own risk. This may violate Anthropic's Terms of Service.
+ * This is based on the claude-hud implementation:
+ * https://github.com/jarrodwatts/claude-hud/blob/main/src/usage-api.ts
  */
-class ClaudePersonalApiClient(
-    private val sessionKey: String,
-    private val organizationId: String
+class ClaudeOAuthApiClient(
+    private val accessToken: String
 ) {
     private val client: OkHttpClient
     private val gson = Gson()
+
+    companion object {
+        private const val OAUTH_API_HOST = "https://api.anthropic.com"
+        private const val USAGE_ENDPOINT = "/api/oauth/usage"
+        private const val ANTHROPIC_BETA_HEADER = "oauth-2025-04-20"
+        private const val USER_AGENT = "claude-usage-plugin/1.0"
+        private const val TIMEOUT_MS = 5000L
+    }
 
     init {
         val loggingInterceptor = HttpLoggingInterceptor().apply {
@@ -30,22 +38,26 @@ class ClaudePersonalApiClient(
 
         client = OkHttpClient.Builder()
             .addInterceptor(loggingInterceptor)
-            .connectTimeout(30, TimeUnit.SECONDS)
-            .readTimeout(30, TimeUnit.SECONDS)
-            .writeTimeout(30, TimeUnit.SECONDS)
+            .connectTimeout(TIMEOUT_MS, TimeUnit.MILLISECONDS)
+            .readTimeout(TIMEOUT_MS, TimeUnit.MILLISECONDS)
+            .writeTimeout(TIMEOUT_MS, TimeUnit.MILLISECONDS)
             .build()
     }
 
-    suspend fun getPersonalUsage(): Result<PersonalUsageResponse> {
+    /**
+     * Fetches usage data from the OAuth API endpoint.
+     */
+    suspend fun getUsage(): Result<PersonalUsageResponse> {
         return retryWithExponentialBackoff {
             withContext(Dispatchers.IO) {
                 try {
-                    val url = "https://claude.ai/api/organizations/$organizationId/usage"
+                    val url = "$OAUTH_API_HOST$USAGE_ENDPOINT"
 
                     val httpRequest = Request.Builder()
                         .url(url)
-                        .header("Cookie", "sessionKey=$sessionKey")
-                        .header("User-Agent", "AnthropicUsagePlugin/1.0")
+                        .header("Authorization", "Bearer $accessToken")
+                        .header("anthropic-beta", ANTHROPIC_BETA_HEADER)
+                        .header("User-Agent", USER_AGENT)
                         .header("Accept", "application/json")
                         .get()
                         .build()
@@ -55,7 +67,7 @@ class ClaudePersonalApiClient(
                     if (response.isSuccessful) {
                         val body = response.body?.string()
                         if (body != null) {
-                            val usageResponse = gson.fromJson(body, PersonalUsageResponse::class.java)
+                            val usageResponse = parseUsageResponse(body)
                             Result.success(usageResponse)
                         } else {
                             Result.failure(ClaudeApiException(response.code, "Empty response body"))
@@ -71,6 +83,14 @@ class ClaudePersonalApiClient(
         }
     }
 
+    /**
+     * Parses the OAuth usage response.
+     * The response format is similar to the web API but may have slight differences.
+     */
+    private fun parseUsageResponse(json: String): PersonalUsageResponse {
+        return gson.fromJson(json, PersonalUsageResponse::class.java)
+    }
+
     private suspend fun <T> retryWithExponentialBackoff(
         maxRetries: Int = 3,
         initialDelayMillis: Long = 1000,
@@ -82,23 +102,23 @@ class ClaudePersonalApiClient(
         repeat(maxRetries) { attempt ->
             val result = block()
 
-            // Return immediately on success
+            // Return immediately on success.
             if (result.isSuccess) {
                 return result
             }
 
-            // Don't retry on auth errors
+            // Don't retry on auth errors.
             val exception = result.exceptionOrNull()
             if (exception is ClaudeApiException && exception.isUnauthorized) {
                 return result
             }
 
-            // Last attempt, return the failure
+            // Last attempt, return the failure.
             if (attempt == maxRetries - 1) {
                 return result
             }
 
-            // Wait before retrying
+            // Wait before retrying.
             delay(currentDelay)
             currentDelay = (currentDelay * factor).toLong().coerceAtMost(maxDelayMillis)
         }
@@ -107,6 +127,9 @@ class ClaudePersonalApiClient(
     }
 }
 
+/**
+ * Exception for Claude API errors.
+ */
 class ClaudeApiException(
     val statusCode: Int,
     override val message: String
@@ -123,9 +146,9 @@ class ClaudeApiException(
 
     fun getUserMessage(): String {
         return when {
-            isUnauthorized -> "Invalid session key or organization ID. Please check your credentials in settings."
+            isUnauthorized -> "Invalid or expired access token. Please check your credentials."
             isRateLimited -> "Rate limit exceeded. Will retry later."
-            isServerError -> "Claude.ai is currently unavailable. Will retry later."
+            isServerError -> "Claude API is currently unavailable. Will retry later."
             else -> "Failed to fetch usage data: $message"
         }
     }

--- a/src/main/kotlin/com/example/anthropic/services/AnthropicUsageService.kt
+++ b/src/main/kotlin/com/example/anthropic/services/AnthropicUsageService.kt
@@ -45,21 +45,17 @@ class AnthropicUsageService : Disposable {
         log.info("Starting usage tracking")
         stopTracking()
 
-        val sessionKey = settings.getSecureSessionKey()
-        val organizationId = settings.organizationId
-
-        if (sessionKey.isNullOrBlank() || organizationId.isBlank()) {
-            log.info("No session key or organization ID configured, skipping usage tracking")
+        val initialized = initializeApiService()
+        if (!initialized) {
+            log.info("API service not initialized, skipping usage tracking")
             return
         }
 
-        apiService.initialize(sessionKey, organizationId)
-
         refreshJob = scope.launch {
-            // Initial fetch
+            // Initial fetch.
             fetchAndPublishUsage()
 
-            // Periodic refresh
+            // Periodic refresh.
             while (isActive) {
                 delay(settings.refreshIntervalMinutes * 60 * 1000L)
                 fetchAndPublishUsage()
@@ -67,6 +63,29 @@ class AnthropicUsageService : Disposable {
         }
 
         log.info("Usage tracking started with ${settings.refreshIntervalMinutes} minute interval")
+    }
+
+    /**
+     * Initialize the API service.
+     * Returns true if successfully initialized.
+     */
+    private fun initializeApiService(): Boolean {
+        return if (settings.useManualToken) {
+            val accessToken = settings.getSecureAccessToken()
+            if (accessToken.isNullOrBlank()) {
+                log.info("No manual access token configured")
+                return false
+            }
+            apiService.initializeWithToken(accessToken)
+            true
+        } else {
+            val success = apiService.initializeWithAutoDiscovery()
+            if (!success) {
+                log.info("OAuth auto-discovery failed, no credentials found")
+                publishError("No Claude Code credentials found. Please install Claude Code and sign in.")
+            }
+            success
+        }
     }
 
     fun stopTracking() {
@@ -82,16 +101,16 @@ class AnthropicUsageService : Disposable {
     }
 
     private suspend fun fetchAndPublishUsage() {
-        log.info("Fetching usage data from Anthropic API")
+        log.info("Fetching usage data")
 
         val result = apiService.fetchCurrentUsage()
 
         result.onSuccess { usageData ->
-            log.info("Successfully fetched usage data: 5h=${usageData.fiveHourUtilization}% 7d=${usageData.sevenDayUtilization}% (max=${usageData.percentage}%)")
+            log.info("Successfully fetched usage data: 5h=${usageData.fiveHourUtilization}% 7d=${usageData.sevenDayUtilization}%")
             cache.update(usageData)
             publishUpdate(usageData)
 
-            // Check if notification needed
+            // Check if notification needed.
             if (settings.showNotifications && shouldShowNotification(usageData)) {
                 showUsageWarning(usageData)
             }
@@ -108,10 +127,10 @@ class AnthropicUsageService : Disposable {
     }
 
     private fun shouldShowNotification(data: UsageData): Boolean {
-        val currentPercentage = data.percentage.toInt()
+        val currentPercentage = data.fiveHourUtilization.toInt()
         val threshold = settings.notifyAtPercentage
 
-        // Only show notification if we've crossed the threshold and haven't notified at this level yet
+        // Only show notification if we've crossed the threshold and haven't notified at this level yet.
         if (currentPercentage >= threshold && lastNotificationPercentage < threshold) {
             lastNotificationPercentage = currentPercentage
             return true
@@ -137,15 +156,15 @@ class AnthropicUsageService : Disposable {
             val notification = NotificationGroupManager.getInstance()
                 .getNotificationGroup("Anthropic Usage Alerts")
                 .createNotification(
-                    "Claude.ai Usage Warning",
-                    "You have used ${String.format("%.1f", data.percentage)}% of your usage limit",
+                    "Claude Usage Warning",
+                    "5-hour limit: ${String.format("%.1f", data.fiveHourUtilization)}%",
                     NotificationType.WARNING
                 )
 
             notification.addAction(object : AnAction("View Settings") {
                 override fun actionPerformed(e: AnActionEvent) {
                     ShowSettingsUtil.getInstance()
-                        .showSettingsDialog(e.project, "Anthropic API Settings")
+                        .showSettingsDialog(e.project, "Claudia Settings")
                     notification.expire()
                 }
             })
@@ -162,6 +181,13 @@ class AnthropicUsageService : Disposable {
         }
     }
 
+    /**
+     * Check if OAuth credentials can be auto-discovered.
+     */
+    fun canAutoDiscoverCredentials(): Boolean {
+        return apiService.canAutoDiscoverCredentials()
+    }
+
     override fun dispose() {
         log.info("Disposing AnthropicUsageService")
         scope.cancel()
@@ -169,9 +195,10 @@ class AnthropicUsageService : Disposable {
     }
 
     /**
-     * Project listener to start tracking when first project opens
+     * Project listener to start tracking when first project opens.
      */
     class ProjectListener : ProjectManagerListener {
+        @Suppress("DEPRECATION")
         override fun projectOpened(project: Project) {
             service<AnthropicUsageService>().startTracking()
         }

--- a/src/main/kotlin/com/example/anthropic/settings/AnthropicSettingsComponent.kt
+++ b/src/main/kotlin/com/example/anthropic/settings/AnthropicSettingsComponent.kt
@@ -1,10 +1,12 @@
 package com.example.anthropic.settings
 
 import com.example.anthropic.api.AnthropicApiService
+import com.example.anthropic.api.ClaudeCredentialDiscovery
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.progress.Task
+import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBPasswordField
 import com.intellij.ui.components.JBTextField
@@ -13,43 +15,58 @@ import com.intellij.util.ui.JBUI
 import kotlinx.coroutines.runBlocking
 import java.awt.BorderLayout
 import java.awt.Color
-import java.awt.Cursor
 import javax.swing.*
 
 class AnthropicSettingsComponent {
     val panel: JPanel
-    private val sessionKeyField = JBPasswordField()
-    private val organizationIdField = JBTextField()
+
+    // Credentials.
+    private val useManualTokenCheckbox = JBCheckBox("Use manual access token")
+    private val accessTokenField = JBPasswordField()
+    private val autoDiscoveryStatusLabel = JBLabel()
+    private val checkCredentialsButton = JButton("Check Credentials")
+
+    // Common fields.
     private val refreshIntervalField = JBTextField()
     private val showNotificationsCheckbox = JCheckBox("Show usage notifications")
     private val notifyAtPercentageField = JBTextField()
     private val testConnectionButton = JButton("Test Connection")
     private val statusLabel = JBLabel()
 
+    private val credentialDiscovery = ClaudeCredentialDiscovery()
+
     init {
-        // Set default values
+        // Set default values.
         refreshIntervalField.text = "5"
         notifyAtPercentageField.text = "90"
 
-        // Create help labels
-        val sessionKeyHelpLabel = JBLabel("<html><i>Get your sessionKey cookie from " +
-                "<a href='https://claude.ai'>claude.ai</a>" +
-                " (see instructions below)</i></html>")
-        sessionKeyHelpLabel.cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+        // Access token field enabled state depends on checkbox.
+        accessTokenField.isEnabled = false
+        useManualTokenCheckbox.addActionListener {
+            accessTokenField.isEnabled = useManualTokenCheckbox.isSelected
+            checkCredentialsButton.isEnabled = !useManualTokenCheckbox.isSelected
+            if (!useManualTokenCheckbox.isSelected) {
+                checkOAuthCredentials()
+            }
+        }
 
-        val orgIdHelpLabel = JBLabel("<html><i>Find your organization ID in the Network tab " +
-                "(format: 14038684-39d3-451d-99ca-0db1367c3edd)</i></html>")
+        checkCredentialsButton.addActionListener {
+            checkOAuthCredentials()
+        }
 
-        // Build the form
+        // Build the form.
         panel = FormBuilder.createFormBuilder()
-            .addLabeledComponent("Session Key:", sessionKeyField, 1, false)
-            .addComponentToRightColumn(sessionKeyHelpLabel, 0)
+            .addComponent(JBLabel("<html><b>Credentials</b></html>"))
+            .addVerticalGap(5)
+            .addComponent(createAutoDiscoveryPanel())
             .addVerticalGap(10)
-            .addLabeledComponent("Organization ID:", organizationIdField, 1, false)
-            .addComponentToRightColumn(orgIdHelpLabel, 0)
+            .addComponent(useManualTokenCheckbox)
+            .addLabeledComponent("Access Token:", accessTokenField, 1, false)
             .addVerticalGap(15)
             .addSeparator()
             .addVerticalGap(10)
+            .addComponent(JBLabel("<html><b>Settings</b></html>"))
+            .addVerticalGap(5)
             .addLabeledComponent("Refresh interval (minutes):", refreshIntervalField, 1, false)
             .addVerticalGap(10)
             .addComponent(showNotificationsCheckbox)
@@ -63,9 +80,37 @@ class AnthropicSettingsComponent {
             .addComponentFillVertically(JPanel(), 0)
             .panel
 
-        // Add test connection button listener
+        // Test connection button listener.
         testConnectionButton.addActionListener {
             testConnection()
+        }
+
+        // Check credentials on init.
+        checkOAuthCredentials()
+    }
+
+    private fun createAutoDiscoveryPanel(): JPanel {
+        val statusPanel = JPanel(BorderLayout(10, 0))
+        statusPanel.add(JBLabel("Auto-discovery:"), BorderLayout.WEST)
+        statusPanel.add(autoDiscoveryStatusLabel, BorderLayout.CENTER)
+        statusPanel.add(checkCredentialsButton, BorderLayout.EAST)
+        return statusPanel
+    }
+
+    private fun checkOAuthCredentials() {
+        val credentials = credentialDiscovery.discoverAccessToken()
+        if (credentials != null) {
+            val sourceStr = when (credentials.source) {
+                com.example.anthropic.api.CredentialSource.FILE -> "~/.claude/.credentials.json"
+                com.example.anthropic.api.CredentialSource.KEYCHAIN -> "macOS Keychain"
+                com.example.anthropic.api.CredentialSource.MANUAL -> "manual"
+            }
+            val expiredStr = if (credentials.isExpired()) " (EXPIRED)" else ""
+            autoDiscoveryStatusLabel.text = "✓ Found in $sourceStr$expiredStr"
+            autoDiscoveryStatusLabel.foreground = if (credentials.isExpired()) Color(255, 165, 0) else Color(0, 128, 0)
+        } else {
+            autoDiscoveryStatusLabel.text = "✗ No credentials found"
+            autoDiscoveryStatusLabel.foreground = Color(255, 0, 0)
         }
     }
 
@@ -80,24 +125,21 @@ class AnthropicSettingsComponent {
     private fun createInstructionsPanel(): JPanel {
         val instructionsText = """
             <html>
-            <h3>How to get your Session Key:</h3>
+            <h3>Auto-discovery (Recommended)</h3>
+            <p>If you have Claude Code installed and signed in, credentials will be automatically discovered from macOS Keychain.</p>
             <ol>
-              <li>Open <a href='https://claude.ai'>claude.ai</a> in your browser and log in</li>
-              <li>Press <b>F12</b> to open DevTools</li>
-              <li>Go to <b>Application</b> tab → <b>Cookies</b> → https://claude.ai</li>
-              <li>Find the <b>sessionKey</b> cookie and copy its value</li>
-              <li>Paste it in the "Session Key" field above</li>
+              <li>Install <a href='https://claude.ai/download'>Claude Code</a></li>
+              <li>Sign in with your Claude account</li>
+              <li>Credentials will be auto-discovered</li>
             </ol>
-            <h3>How to get your Organization ID:</h3>
+
+            <h3>Manual Token</h3>
+            <p>If auto-discovery doesn't work, you can enter your access token manually:</p>
             <ol>
-              <li>While on <a href='https://claude.ai/settings/usage'>claude.ai/settings/usage</a></li>
-              <li>Open DevTools (<b>F12</b>) → <b>Network</b> tab</li>
-              <li>Refresh the page (<b>F5</b>)</li>
-              <li>Look for a request to <b>/api/organizations/{id}/usage</b></li>
-              <li>Copy the UUID from the URL (format: 14038684-39d3-451d-99ca-0db1367c3edd)</li>
-              <li>Paste it in the "Organization ID" field above</li>
+              <li>Find your token in <code>~/.claude/.credentials.json</code></li>
+              <li>Or extract it from macOS Keychain (service: "Claude Code-credentials")</li>
+              <li>Check "Use manual access token" and paste the token</li>
             </ol>
-            <p><b>⚠️ Warning:</b> This uses unofficial API. Use at your own risk.</p>
             </html>
         """.trimIndent()
 
@@ -108,16 +150,19 @@ class AnthropicSettingsComponent {
         return instructionsPanel
     }
 
-    var sessionKey: String?
-        get() = String(sessionKeyField.password).takeIf { it.isNotBlank() }
+    // Property accessors.
+    var useManualToken: Boolean
+        get() = useManualTokenCheckbox.isSelected
         set(value) {
-            sessionKeyField.text = value ?: ""
+            useManualTokenCheckbox.isSelected = value
+            accessTokenField.isEnabled = value
+            checkCredentialsButton.isEnabled = !value
         }
 
-    var organizationId: String
-        get() = organizationIdField.text
+    var accessToken: String?
+        get() = String(accessTokenField.password).takeIf { it.isNotBlank() }
         set(value) {
-            organizationIdField.text = value
+            accessTokenField.text = value ?: ""
         }
 
     var refreshInterval: Int
@@ -139,34 +184,37 @@ class AnthropicSettingsComponent {
         }
 
     private fun testConnection() {
-        val key = sessionKey
-        val orgId = organizationId
-
-        if (key.isNullOrBlank()) {
-            setStatus("Please enter a session key", StatusType.ERROR)
+        // Validate inputs.
+        if (useManualToken && accessToken.isNullOrBlank()) {
+            setStatus("Please enter an access token", StatusType.ERROR)
             return
         }
 
-        if (orgId.isBlank()) {
-            setStatus("Please enter an organization ID", StatusType.ERROR)
+        if (!useManualToken && credentialDiscovery.discoverAccessToken() == null) {
+            setStatus("No credentials found. Install Claude Code and sign in.", StatusType.ERROR)
             return
         }
 
         testConnectionButton.isEnabled = false
         setStatus("Testing connection...", StatusType.INFO)
 
-        // Test in background
+        // Test in background.
         ProgressManager.getInstance().run(object : Task.Backgroundable(
-            null, "Testing Claude.ai Connection", true
+            null, "Testing Claude API Connection", true
         ) {
             var success = false
             var errorMessage = ""
 
             override fun run(indicator: ProgressIndicator) {
-                indicator.text = "Connecting to claude.ai..."
+                indicator.text = "Connecting to Claude API..."
 
                 val apiService = AnthropicApiService()
-                apiService.initialize(key, orgId)
+
+                if (useManualToken) {
+                    apiService.initializeWithToken(accessToken!!)
+                } else {
+                    apiService.initializeWithAutoDiscovery()
+                }
 
                 val result = runBlocking {
                     apiService.testConnection()
@@ -203,9 +251,9 @@ class AnthropicSettingsComponent {
         ApplicationManager.getApplication().invokeLater {
             statusLabel.text = message
             statusLabel.foreground = when (type) {
-                StatusType.SUCCESS -> Color(0, 128, 0)  // Green
-                StatusType.ERROR -> Color(255, 0, 0)     // Red
-                StatusType.INFO -> Color(0, 0, 0)        // Black
+                StatusType.SUCCESS -> Color(0, 128, 0)  // Green.
+                StatusType.ERROR -> Color(255, 0, 0)     // Red.
+                StatusType.INFO -> Color(0, 0, 0)        // Black.
             }
         }
     }

--- a/src/main/kotlin/com/example/anthropic/settings/AnthropicSettingsConfigurable.kt
+++ b/src/main/kotlin/com/example/anthropic/settings/AnthropicSettingsConfigurable.kt
@@ -9,20 +9,19 @@ class AnthropicSettingsConfigurable : Configurable {
     private var component: AnthropicSettingsComponent? = null
     private val settings = service<AnthropicSettingsState>()
 
-    override fun getDisplayName() = "Claude.ai Usage Settings"
+    override fun getDisplayName() = "Claudia Settings"
 
     override fun createComponent(): JComponent {
         component = AnthropicSettingsComponent()
-        reset()  // Load current settings into UI
+        reset()  // Load current settings into UI.
         return component!!.panel
     }
 
     override fun isModified(): Boolean {
         val c = component ?: return false
 
-        // Check if any setting has changed
-        return c.sessionKey != settings.getSecureSessionKey() ||
-               c.organizationId != settings.organizationId ||
+        return c.useManualToken != settings.useManualToken ||
+               c.accessToken != settings.getSecureAccessToken() ||
                c.refreshInterval != settings.refreshIntervalMinutes ||
                c.showNotifications != settings.showNotifications ||
                c.notifyAtPercentage != settings.notifyAtPercentage
@@ -31,22 +30,24 @@ class AnthropicSettingsConfigurable : Configurable {
     override fun apply() {
         val c = component ?: return
 
-        // Save session key securely
-        val oldSessionKey = settings.getSecureSessionKey()
-        val oldOrgId = settings.organizationId
-        val newSessionKey = c.sessionKey
-        val newOrgId = c.organizationId
+        // Save old values to detect changes.
+        val oldUseManualToken = settings.useManualToken
+        val oldAccessToken = settings.getSecureAccessToken()
 
-        settings.setSecureSessionKey(newSessionKey)
-        settings.organizationId = newOrgId
+        // Save new values.
+        settings.useManualToken = c.useManualToken
+        settings.setSecureAccessToken(c.accessToken)
 
-        // Save other settings
+        // Save other settings.
         settings.refreshIntervalMinutes = c.refreshInterval
         settings.showNotifications = c.showNotifications
         settings.notifyAtPercentage = c.notifyAtPercentage
 
-        // Restart usage tracking if credentials changed or refresh interval changed
-        if (oldSessionKey != newSessionKey || oldOrgId != newOrgId || isModified) {
+        // Restart usage tracking if credentials changed.
+        val credentialsChanged = oldUseManualToken != c.useManualToken ||
+                oldAccessToken != c.accessToken
+
+        if (credentialsChanged) {
             val usageService = service<AnthropicUsageService>()
             usageService.restartTracking()
         }
@@ -55,9 +56,8 @@ class AnthropicSettingsConfigurable : Configurable {
     override fun reset() {
         val c = component ?: return
 
-        // Load current settings into UI
-        c.sessionKey = settings.getSecureSessionKey()
-        c.organizationId = settings.organizationId
+        c.useManualToken = settings.useManualToken
+        c.accessToken = settings.getSecureAccessToken()
         c.refreshInterval = settings.refreshIntervalMinutes
         c.showNotifications = settings.showNotifications
         c.notifyAtPercentage = settings.notifyAtPercentage

--- a/src/main/kotlin/com/example/anthropic/settings/AnthropicSettingsState.kt
+++ b/src/main/kotlin/com/example/anthropic/settings/AnthropicSettingsState.kt
@@ -21,8 +21,17 @@ class AnthropicSettingsState : PersistentStateComponent<AnthropicSettingsState.S
         var refreshIntervalMinutes: Int = 5,
         var showNotifications: Boolean = true,
         var notifyAtPercentage: Int = 90,
-        var organizationId: String = ""  // claude.ai organization ID
+        var useManualToken: Boolean = false,  // false = auto-discovery, true = manual token
+        var displayMode: UsageDisplayMode = UsageDisplayMode.FIVE_HOUR  // Which limit to show in status bar
     )
+
+    /**
+     * Which usage limit to display in the status bar.
+     */
+    enum class UsageDisplayMode {
+        FIVE_HOUR,
+        SEVEN_DAY
+    }
 
     override fun getState(): State = myState
 
@@ -30,7 +39,7 @@ class AnthropicSettingsState : PersistentStateComponent<AnthropicSettingsState.S
         myState = state
     }
 
-    // Convenience accessors
+    // Convenience accessors.
     var refreshIntervalMinutes: Int
         get() = myState.refreshIntervalMinutes
         set(value) {
@@ -49,43 +58,49 @@ class AnthropicSettingsState : PersistentStateComponent<AnthropicSettingsState.S
             myState.notifyAtPercentage = value
         }
 
-    var organizationId: String
-        get() = myState.organizationId
+    var useManualToken: Boolean
+        get() = myState.useManualToken
         set(value) {
-            myState.organizationId = value
+            myState.useManualToken = value
         }
 
-    // Secure sessionKey storage using PasswordSafe
-    fun getSecureSessionKey(): String? {
+    var displayMode: UsageDisplayMode
+        get() = myState.displayMode
+        set(value) {
+            myState.displayMode = value
+        }
+
+    // Secure OAuth access token storage (for manual mode).
+    fun getSecureAccessToken(): String? {
         val passwordSafe = PasswordSafe.instance
-        val attributes = createCredentialAttributes()
+        val attributes = createCredentialAttributes(CREDENTIAL_ACCESS_TOKEN)
         return passwordSafe.getPassword(attributes)
     }
 
-    fun setSecureSessionKey(key: String?) {
+    fun setSecureAccessToken(token: String?) {
         val passwordSafe = PasswordSafe.instance
-        val attributes = createCredentialAttributes()
+        val attributes = createCredentialAttributes(CREDENTIAL_ACCESS_TOKEN)
 
-        if (key != null && key.isNotBlank()) {
-            val credentials = Credentials(CREDENTIAL_USER, key)
+        if (token != null && token.isNotBlank()) {
+            val credentials = Credentials(CREDENTIAL_ACCESS_TOKEN, token)
             passwordSafe.set(attributes, credentials)
         } else {
             passwordSafe.set(attributes, null)
         }
     }
 
-    fun hasSessionKey(): Boolean {
-        return !getSecureSessionKey().isNullOrBlank()
+    fun hasAccessToken(): Boolean {
+        return !getSecureAccessToken().isNullOrBlank()
     }
 
-    private fun createCredentialAttributes(): CredentialAttributes {
+    private fun createCredentialAttributes(key: String): CredentialAttributes {
         return CredentialAttributes(
-            serviceName = "ClaudeAiSessionKey",
-            userName = CREDENTIAL_USER
+            serviceName = "ClaudeUsagePlugin",
+            userName = key
         )
     }
 
     companion object {
-        private const val CREDENTIAL_USER = "claude-ai-session-key"
+        private const val CREDENTIAL_ACCESS_TOKEN = "claude-oauth-access-token"
     }
 }

--- a/src/main/kotlin/com/example/anthropic/statusbar/AnthropicUsageWidget.kt
+++ b/src/main/kotlin/com/example/anthropic/statusbar/AnthropicUsageWidget.kt
@@ -4,6 +4,7 @@ import com.example.anthropic.api.models.UsageData
 import com.example.anthropic.services.AnthropicUsageService
 import com.example.anthropic.services.UsageUpdateListener
 import com.example.anthropic.settings.AnthropicSettingsConfigurable
+import com.example.anthropic.settings.AnthropicSettingsState
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.service
 import com.intellij.openapi.options.ShowSettingsUtil
@@ -24,13 +25,16 @@ import javax.swing.*
 class AnthropicUsageWidget(private val project: Project) : CustomStatusBarWidget, StatusBarWidget.Multiframe {
     private val panel = CustomProgressPanel()
     private val usageService = service<AnthropicUsageService>()
+    private val settings = service<AnthropicSettingsState>()
+    private var currentData: UsageData? = null
 
     init {
         setupUI()
         subscribeToUsageUpdates()
 
-        // Load initial data if available
+        // Load initial data if available.
         usageService.getCurrentUsage()?.let { data ->
+            currentData = data
             updateUI(data)
         }
     }
@@ -44,14 +48,17 @@ class AnthropicUsageWidget(private val project: Project) : CustomStatusBarWidget
     }
 
     private fun setupUI() {
-        panel.toolTipText = "Claude.ai Usage - Click for details"
+        panel.toolTipText = "Claude Usage - Click for details"
 
-        // Click handler to open settings
         panel.addMouseListener(object : MouseAdapter() {
             override fun mouseClicked(e: MouseEvent) {
                 if (SwingUtilities.isLeftMouseButton(e)) {
+                    // Left click - open settings.
                     ShowSettingsUtil.getInstance()
                         .showSettingsDialog(project, AnthropicSettingsConfigurable::class.java)
+                } else if (SwingUtilities.isRightMouseButton(e)) {
+                    // Right click - show context menu.
+                    showContextMenu(e)
                 }
             }
 
@@ -65,11 +72,52 @@ class AnthropicUsageWidget(private val project: Project) : CustomStatusBarWidget
         })
     }
 
+    private fun showContextMenu(e: MouseEvent) {
+        val popup = JPopupMenu()
+
+        // Display mode options.
+        val fiveHourItem = JCheckBoxMenuItem("Show 5-hour limit")
+        fiveHourItem.isSelected = settings.displayMode == AnthropicSettingsState.UsageDisplayMode.FIVE_HOUR
+        fiveHourItem.addActionListener {
+            settings.displayMode = AnthropicSettingsState.UsageDisplayMode.FIVE_HOUR
+            currentData?.let { updateUI(it) }
+        }
+
+        val sevenDayItem = JCheckBoxMenuItem("Show 7-day limit")
+        sevenDayItem.isSelected = settings.displayMode == AnthropicSettingsState.UsageDisplayMode.SEVEN_DAY
+        sevenDayItem.addActionListener {
+            settings.displayMode = AnthropicSettingsState.UsageDisplayMode.SEVEN_DAY
+            currentData?.let { updateUI(it) }
+        }
+
+        popup.add(fiveHourItem)
+        popup.add(sevenDayItem)
+        popup.addSeparator()
+
+        // Refresh action.
+        val refreshItem = JMenuItem("Refresh")
+        refreshItem.addActionListener {
+            usageService.forceRefresh()
+        }
+        popup.add(refreshItem)
+
+        // Settings action.
+        val settingsItem = JMenuItem("Settings...")
+        settingsItem.addActionListener {
+            ShowSettingsUtil.getInstance()
+                .showSettingsDialog(project, AnthropicSettingsConfigurable::class.java)
+        }
+        popup.add(settingsItem)
+
+        popup.show(e.component, e.x, e.y)
+    }
+
     private fun subscribeToUsageUpdates() {
         ApplicationManager.getApplication().messageBus.connect(this)
             .subscribe(AnthropicUsageService.USAGE_TOPIC, object : UsageUpdateListener {
                 override fun onUsageUpdated(data: UsageData) {
                     ApplicationManager.getApplication().invokeLater {
+                        currentData = data
                         updateUI(data)
                     }
                 }
@@ -83,21 +131,36 @@ class AnthropicUsageWidget(private val project: Project) : CustomStatusBarWidget
     }
 
     private fun updateUI(data: UsageData) {
-        val percentage = data.percentage.toInt().coerceIn(0, 100)
-
-        // Format: "35% • 2h 15m" or just "35%" if no time data
-        val timeRemaining = data.fiveHourTimeRemaining
-        val text = if (timeRemaining != null) {
-            "$percentage% • $timeRemaining"
-        } else {
-            "$percentage%"
+        // Get percentage based on display mode.
+        val (percentage, timeRemaining, label) = when (settings.displayMode) {
+            AnthropicSettingsState.UsageDisplayMode.FIVE_HOUR -> {
+                Triple(
+                    data.fiveHourUtilization.toInt().coerceIn(0, 100),
+                    data.fiveHourTimeRemaining,
+                    "5h"
+                )
+            }
+            AnthropicSettingsState.UsageDisplayMode.SEVEN_DAY -> {
+                Triple(
+                    data.sevenDayUtilization.toInt().coerceIn(0, 100),
+                    null,  // No time remaining for 7-day.
+                    "7d"
+                )
+            }
         }
 
-        // Color based on usage percentage
+        // Format: "5h: 35% • 2h 15m" or "7d: 12%".
+        val text = if (timeRemaining != null) {
+            "$label: $percentage% • $timeRemaining"
+        } else {
+            "$label: $percentage%"
+        }
+
+        // Color based on usage percentage.
         val color = when {
-            percentage >= 90 -> JBColor(Color(200, 50, 50), Color(180, 40, 40))      // Red
-            percentage >= 75 -> JBColor(Color(255, 165, 0), Color(200, 130, 0))      // Orange
-            else -> JBColor(Color(50, 150, 50), Color(80, 170, 80))                  // Green
+            percentage >= 90 -> JBColor(Color(200, 50, 50), Color(180, 40, 40))      // Red.
+            percentage >= 75 -> JBColor(Color(255, 165, 0), Color(200, 130, 0))      // Orange.
+            else -> JBColor(Color(50, 150, 50), Color(80, 170, 80))                  // Green.
         }
 
         panel.updateUsage(percentage, text, color)
@@ -123,27 +186,26 @@ class AnthropicUsageWidget(private val project: Project) : CustomStatusBarWidget
 
         return """
             <html>
-            <b>Claude.ai Usage (Personal Account)</b><br/>
+            <b>Claude Usage</b><br/>
             <br/>
             <b>5-Hour Limit:</b> ${String.format("%.1f", data.fiveHourUtilization)}%<br/>
             ${data.formattedFiveHourResetsAt?.let { "&nbsp;&nbsp;Resets at: $it<br/>" } ?: ""}
+            ${data.fiveHourTimeRemaining?.let { "&nbsp;&nbsp;Time remaining: $it<br/>" } ?: ""}
             <br/>
             <b>7-Day Limit:</b> ${String.format("%.1f", data.sevenDayUtilization)}%<br/>
             ${data.formattedSevenDayResetsAt?.let { "&nbsp;&nbsp;Resets at: $it<br/>" } ?: ""}
-            <br/>
-            <b>Overall Usage:</b> ${String.format("%.1f", data.percentage)}%<br/>
             <br/>
             <i>Last Updated: ${data.formattedLastUpdate}</i>
             $breakdown
             <br/>
             <br/>
-            <i>Click to open settings</i>
+            <i>Left-click: Settings | Right-click: Options</i>
             </html>
         """.trimIndent()
     }
 
     override fun install(statusBar: StatusBar) {
-        // Widget installed in status bar
+        // Widget installed in status bar.
     }
 
     override fun dispose() {
@@ -151,7 +213,7 @@ class AnthropicUsageWidget(private val project: Project) : CustomStatusBarWidget
     }
 
     /**
-     * Custom panel with progress bar painting (like Memory Indicator)
+     * Custom panel with progress bar painting (like Memory Indicator).
      */
     private class CustomProgressPanel : JPanel() {
         private var percentage: Int = 0
@@ -159,7 +221,7 @@ class AnthropicUsageWidget(private val project: Project) : CustomStatusBarWidget
         private var barColor: Color = JBColor.GREEN
 
         init {
-            preferredSize = Dimension(120, 20)
+            preferredSize = Dimension(130, 20)
             border = JBUI.Borders.empty(0, 2)
             isOpaque = false
         }
@@ -184,22 +246,22 @@ class AnthropicUsageWidget(private val project: Project) : CustomStatusBarWidget
             val x = insets.left
             val y = insets.top
 
-            // Draw background
+            // Draw background.
             g2.color = if (UIUtil.isUnderDarcula()) Gray._85 else Gray._200
             g2.fillRoundRect(x, y, width, height, 3, 3)
 
-            // Draw filled progress
+            // Draw filled progress.
             if (percentage > 0) {
                 val filledWidth = (width * percentage / 100).coerceAtLeast(0)
                 g2.color = barColor
                 g2.fillRoundRect(x, y, filledWidth, height, 3, 3)
             }
 
-            // Draw border
+            // Draw border.
             g2.color = if (UIUtil.isUnderDarcula()) Gray._70 else Gray._180
             g2.drawRoundRect(x, y, width - 1, height - 1, 3, 3)
 
-            // Draw text centered
+            // Draw text centered.
             g2.color = if (UIUtil.isUnderDarcula()) Gray._220 else Gray._50
             g2.font = JBUI.Fonts.toolbarSmallComboBoxFont()
 

--- a/src/main/kotlin/com/example/anthropic/statusbar/AnthropicUsageWidgetFactory.kt
+++ b/src/main/kotlin/com/example/anthropic/statusbar/AnthropicUsageWidgetFactory.kt
@@ -1,5 +1,6 @@
 package com.example.anthropic.statusbar
 
+import com.example.anthropic.api.ClaudeCredentialDiscovery
 import com.example.anthropic.settings.AnthropicSettingsState
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
@@ -11,12 +12,16 @@ import com.intellij.openapi.wm.StatusBarWidgetFactory
 class AnthropicUsageWidgetFactory : StatusBarWidgetFactory {
     override fun getId() = "com.example.anthropic.statusbar.widget"
 
-    override fun getDisplayName() = "Claude.ai Usage"
+    override fun getDisplayName() = "Claude Usage"
 
     override fun isAvailable(project: Project): Boolean {
-        // Only show widget if session key is configured
         val settings = service<AnthropicSettingsState>()
-        return settings.hasSessionKey()
+
+        return if (settings.useManualToken) {
+            settings.hasAccessToken()
+        } else {
+            ClaudeCredentialDiscovery().hasCredentials()
+        }
     }
 
     override fun createWidget(project: Project): StatusBarWidget {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -88,9 +88,6 @@
         <projectService
                 serviceImplementation="com.example.anthropic.sessions.SessionService"/>
 
-        <!-- Icon mapping for New UI (expui) -->
-        <iconMapper mappingFile="IconMappings.json"/>
-
         <!-- Session Browser tool window on right sidebar -->
         <toolWindow
                 id="Claude Sessions"


### PR DESCRIPTION
- Replace legacy web API (claude.ai) with official OAuth API (api.anthropic.com)
- Auto-discover credentials from Claude Code (macOS Keychain)
- Remove ClaudePersonalApiClient, add ClaudeOAuthApiClient and ClaudeCredentialDiscovery
- Status bar widget now shows 5-hour limit by default
- Add right-click context menu to switch between 5-hour and 7-day display
- Simplify settings UI (auto-discovery + manual token option)
- Remove iconMapper extension (was causing plugin load errors)