### PR TITLE
Add Memory Viewer tool window

### DIFF
--- a/src/main/kotlin/com/example/anthropic/ClaudiaIcons.kt
+++ b/src/main/kotlin/com/example/anthropic/ClaudiaIcons.kt
@@ -6,4 +6,7 @@ import javax.swing.Icon
 object ClaudiaIcons {
     @JvmField
     val Sessions: Icon = IconLoader.getIcon("/icons/claudiaSessions.svg", ClaudiaIcons::class.java)
+
+    @JvmField
+    val Memory: Icon = IconLoader.getIcon("/icons/claudiaMemory.svg", ClaudiaIcons::class.java)
 }

--- a/src/main/kotlin/com/example/anthropic/memory/MemoryFile.kt
+++ b/src/main/kotlin/com/example/anthropic/memory/MemoryFile.kt
@@ -1,0 +1,18 @@
+package com.example.anthropic.memory
+
+import java.nio.file.Path
+
+data class MemoryFile(
+    val category: MemoryCategory,
+    val path: Path,
+    val displayName: String,
+    val exists: Boolean
+)
+
+enum class MemoryCategory(val label: String) {
+    USER_MEMORY("User Memory"),
+    USER_RULES("User Rules"),
+    PROJECT_MEMORY("Project Memory"),
+    PROJECT_RULES("Project Rules"),
+    AUTO_MEMORY("Auto Memory")
+}

--- a/src/main/kotlin/com/example/anthropic/memory/MemoryService.kt
+++ b/src/main/kotlin/com/example/anthropic/memory/MemoryService.kt
@@ -1,0 +1,283 @@
+package com.example.anthropic.memory
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.project.Project
+import com.intellij.util.messages.Topic
+import java.nio.file.*
+import java.util.concurrent.TimeUnit
+import kotlin.concurrent.thread
+import kotlin.io.path.exists
+import kotlin.io.path.extension
+import kotlin.io.path.isDirectory
+import kotlin.io.path.name
+
+@Service(Service.Level.PROJECT)
+class MemoryService(private val project: Project) : Disposable {
+    private val log = logger<MemoryService>()
+    @Volatile
+    private var cachedFiles: List<MemoryFile> = emptyList()
+    private var watcherThread: Thread? = null
+
+    companion object {
+        val MEMORY_CHANGED_TOPIC = Topic.create(
+            "Claude Memory Changed",
+            MemoryChangedListener::class.java
+        )
+
+        fun getInstance(project: Project): MemoryService =
+            project.getService(MemoryService::class.java)
+
+        private fun getClaudeHomeDir(): Path {
+            val home = System.getProperty("user.home")
+            return Path.of(home, ".claude")
+        }
+    }
+
+    init {
+        refresh()
+        startFileWatcher()
+    }
+
+    /**
+     * Encode project path to directory name as Claude Code does.
+     * /Users/smidl/Desktop/ccup -> -Users-smidl-Desktop-ccup
+     */
+    private fun encodeProjectPath(projectPath: String): String {
+        return projectPath
+            .replace("\\", "-")
+            .replace("/", "-")
+            .replace(":", "")
+    }
+
+    /**
+     * Discover all memory files across all locations.
+     */
+    private fun discoverMemoryFiles(): List<MemoryFile> {
+        val files = mutableListOf<MemoryFile>()
+        val claudeHome = getClaudeHomeDir()
+        val projectPath = project.basePath ?: return files
+
+        // User Memory: ~/.claude/CLAUDE.md
+        val userMemory = claudeHome.resolve("CLAUDE.md")
+        files.add(MemoryFile(
+            category = MemoryCategory.USER_MEMORY,
+            path = userMemory,
+            displayName = "CLAUDE.md",
+            exists = userMemory.exists()
+        ))
+
+        // User Rules: ~/.claude/rules/*.md
+        val userRulesDir = claudeHome.resolve("rules")
+        if (userRulesDir.exists() && userRulesDir.isDirectory()) {
+            try {
+                Files.list(userRulesDir).use { stream ->
+                    stream.filter { it.extension == "md" }
+                        .sorted()
+                        .forEach { file ->
+                            files.add(MemoryFile(
+                                category = MemoryCategory.USER_RULES,
+                                path = file,
+                                displayName = file.name,
+                                exists = true
+                            ))
+                        }
+                }
+            } catch (e: Exception) {
+                log.warn("Failed to list user rules: ${e.message}")
+            }
+        }
+
+        // Project Memory: {project}/CLAUDE.md
+        val projectRoot = Path.of(projectPath)
+        val projectMemory = projectRoot.resolve("CLAUDE.md")
+        files.add(MemoryFile(
+            category = MemoryCategory.PROJECT_MEMORY,
+            path = projectMemory,
+            displayName = "CLAUDE.md",
+            exists = projectMemory.exists()
+        ))
+
+        // Project Alt: {project}/.claude/CLAUDE.md
+        val projectAltMemory = projectRoot.resolve(".claude").resolve("CLAUDE.md")
+        files.add(MemoryFile(
+            category = MemoryCategory.PROJECT_MEMORY,
+            path = projectAltMemory,
+            displayName = ".claude/CLAUDE.md",
+            exists = projectAltMemory.exists()
+        ))
+
+        // Project Local: {project}/CLAUDE.local.md
+        val projectLocal = projectRoot.resolve("CLAUDE.local.md")
+        files.add(MemoryFile(
+            category = MemoryCategory.PROJECT_MEMORY,
+            path = projectLocal,
+            displayName = "CLAUDE.local.md",
+            exists = projectLocal.exists()
+        ))
+
+        // Project Rules: {project}/.claude/rules/*.md
+        val projectRulesDir = projectRoot.resolve(".claude").resolve("rules")
+        if (projectRulesDir.exists() && projectRulesDir.isDirectory()) {
+            try {
+                Files.list(projectRulesDir).use { stream ->
+                    stream.filter { it.extension == "md" }
+                        .sorted()
+                        .forEach { file ->
+                            files.add(MemoryFile(
+                                category = MemoryCategory.PROJECT_RULES,
+                                path = file,
+                                displayName = file.name,
+                                exists = true
+                            ))
+                        }
+                }
+            } catch (e: Exception) {
+                log.warn("Failed to list project rules: ${e.message}")
+            }
+        }
+
+        // Auto Memory: ~/.claude/projects/{encoded}/memory/*.md
+        val encoded = encodeProjectPath(projectPath)
+        val autoMemoryDir = claudeHome.resolve("projects").resolve(encoded).resolve("memory")
+        if (autoMemoryDir.exists() && autoMemoryDir.isDirectory()) {
+            try {
+                Files.list(autoMemoryDir).use { stream ->
+                    stream.filter { it.extension == "md" }
+                        .sorted()
+                        .forEach { file ->
+                            files.add(MemoryFile(
+                                category = MemoryCategory.AUTO_MEMORY,
+                                path = file,
+                                displayName = file.name,
+                                exists = true
+                            ))
+                        }
+                }
+            } catch (e: Exception) {
+                log.warn("Failed to list auto memory: ${e.message}")
+            }
+        }
+
+        return files
+    }
+
+    /**
+     * Get cached memory files.
+     */
+    fun getMemoryFiles(): List<MemoryFile> = cachedFiles
+
+    /**
+     * Refresh memory files from disk and notify listeners.
+     */
+    fun refresh() {
+        ApplicationManager.getApplication().executeOnPooledThread {
+            val files = discoverMemoryFiles()
+            ApplicationManager.getApplication().invokeLater {
+                cachedFiles = files
+                project.messageBus.syncPublisher(MEMORY_CHANGED_TOPIC).onMemoryChanged()
+            }
+        }
+    }
+
+    /**
+     * Create a file at the given path with optional initial content.
+     */
+    fun createFile(path: Path, content: String = "") {
+        ApplicationManager.getApplication().executeOnPooledThread {
+            try {
+                Files.createDirectories(path.parent)
+                Files.writeString(path, content)
+                refresh()
+            } catch (e: Exception) {
+                log.warn("Failed to create file $path: ${e.message}", e)
+            }
+        }
+    }
+
+    /**
+     * Delete a file at the given path.
+     */
+    fun deleteFile(path: Path) {
+        ApplicationManager.getApplication().executeOnPooledThread {
+            try {
+                Files.deleteIfExists(path)
+                refresh()
+            } catch (e: Exception) {
+                log.warn("Failed to delete file $path: ${e.message}", e)
+            }
+        }
+    }
+
+    /**
+     * Watch relevant directories for file changes.
+     */
+    private fun startFileWatcher() {
+        watcherThread?.interrupt()
+
+        watcherThread = thread(isDaemon = true, name = "claude-memory-watcher") {
+            try {
+                val watchService = FileSystems.getDefault().newWatchService()
+                val claudeHome = getClaudeHomeDir()
+                val projectPath = project.basePath ?: return@thread
+
+                // Register directories that exist.
+                val dirsToWatch = listOfNotNull(
+                    claudeHome.takeIf { it.exists() },
+                    claudeHome.resolve("rules").takeIf { it.exists() },
+                    Path.of(projectPath).takeIf { it.exists() },
+                    Path.of(projectPath, ".claude").takeIf { it.exists() },
+                    Path.of(projectPath, ".claude", "rules").takeIf { it.exists() },
+                    claudeHome.resolve("projects")
+                        .resolve(encodeProjectPath(projectPath))
+                        .resolve("memory").takeIf { it.exists() }
+                )
+
+                for (dir in dirsToWatch) {
+                    try {
+                        dir.register(
+                            watchService,
+                            StandardWatchEventKinds.ENTRY_CREATE,
+                            StandardWatchEventKinds.ENTRY_MODIFY,
+                            StandardWatchEventKinds.ENTRY_DELETE
+                        )
+                    } catch (e: Exception) {
+                        log.warn("Failed to watch directory $dir: ${e.message}")
+                    }
+                }
+
+                while (!Thread.currentThread().isInterrupted) {
+                    val key = watchService.poll(2, TimeUnit.SECONDS)
+                    if (key != null) {
+                        val relevant = key.pollEvents().any { event ->
+                            val context = event.context()?.toString() ?: return@any false
+                            context.endsWith(".md")
+                        }
+                        key.reset()
+                        if (relevant) {
+                            Thread.sleep(200)
+                            refresh()
+                        }
+                    }
+                }
+                watchService.close()
+            } catch (e: InterruptedException) {
+                // Watcher stopped.
+            } catch (e: Exception) {
+                log.warn("Memory file watcher error: ${e.message}", e)
+            }
+        }
+    }
+
+    override fun dispose() {
+        watcherThread?.interrupt()
+        watcherThread = null
+        log.info("Disposing MemoryService")
+    }
+}
+
+interface MemoryChangedListener {
+    fun onMemoryChanged()
+}

--- a/src/main/kotlin/com/example/anthropic/memory/MemoryViewerPanel.kt
+++ b/src/main/kotlin/com/example/anthropic/memory/MemoryViewerPanel.kt
@@ -1,0 +1,402 @@
+package com.example.anthropic.memory
+
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.actionSystem.*
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.Messages
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.ui.JBColor
+import com.intellij.ui.PopupHandler
+import com.intellij.ui.treeStructure.Tree
+import com.intellij.util.ui.JBUI
+import java.awt.BorderLayout
+import java.awt.Component
+import java.awt.Font
+import java.awt.event.MouseAdapter
+import java.awt.event.MouseEvent
+import java.nio.file.Path
+import javax.swing.*
+import javax.swing.tree.DefaultMutableTreeNode
+import javax.swing.tree.DefaultTreeCellRenderer
+import javax.swing.tree.DefaultTreeModel
+import javax.swing.tree.TreePath
+
+class MemoryViewerPanel(
+    private val project: Project,
+    private val parentDisposable: Disposable
+) {
+    val mainPanel: JPanel = JPanel(BorderLayout())
+    private val service = MemoryService.getInstance(project)
+    private val rootNode = DefaultMutableTreeNode("Claude Memory")
+    private val treeModel = DefaultTreeModel(rootNode)
+    private val tree = Tree(treeModel)
+    private val cardLayout = java.awt.CardLayout()
+    private val centerPanel = JPanel(cardLayout)
+    private val emptyLabel = JLabel("No memory files found", SwingConstants.CENTER)
+    private val statusLabel = JLabel()
+    private var statusTimer: Timer? = null
+
+    init {
+        setupUI()
+        loadFiles()
+        subscribeToChanges()
+    }
+
+    private fun setupUI() {
+        // Toolbar.
+        val toolbar = createToolbar()
+        mainPanel.add(toolbar.component, BorderLayout.NORTH)
+
+        // Tree setup.
+        tree.isRootVisible = false
+        tree.showsRootHandles = true
+        tree.cellRenderer = MemoryTreeCellRenderer()
+
+        // Double-click to open file.
+        tree.addMouseListener(object : MouseAdapter() {
+            override fun mouseClicked(e: MouseEvent) {
+                if (e.clickCount == 2) {
+                    val node = tree.lastSelectedPathComponent as? DefaultMutableTreeNode ?: return
+                    val userObj = node.userObject
+                    if (userObj is MemoryFile) {
+                        openOrCreateFile(userObj)
+                    } else if (userObj is NewRuleAction) {
+                        createNewRule(userObj.category, userObj.baseDir)
+                    }
+                }
+            }
+        })
+
+        // Right-click context menu.
+        tree.addMouseListener(object : PopupHandler() {
+            override fun invokePopup(comp: Component, x: Int, y: Int) {
+                val path = tree.getPathForLocation(x, y) ?: return
+                tree.selectionPath = path
+                val node = path.lastPathComponent as? DefaultMutableTreeNode ?: return
+                val userObj = node.userObject
+                if (userObj is MemoryFile) {
+                    showContextMenu(userObj, comp, x, y)
+                }
+            }
+        })
+
+        // Empty state.
+        emptyLabel.foreground = JBColor.GRAY
+        emptyLabel.border = JBUI.Borders.empty(20)
+
+        // Card layout.
+        centerPanel.add(JScrollPane(tree), "tree")
+        centerPanel.add(emptyLabel, "empty")
+        mainPanel.add(centerPanel, BorderLayout.CENTER)
+
+        // Status bar at bottom.
+        statusLabel.foreground = JBColor.GRAY
+        statusLabel.font = statusLabel.font.deriveFont(Font.PLAIN, 11f)
+        statusLabel.border = JBUI.Borders.empty(4, 8)
+        statusLabel.isVisible = false
+        mainPanel.add(statusLabel, BorderLayout.SOUTH)
+    }
+
+    private fun createToolbar(): ActionToolbar {
+        val group = DefaultActionGroup().apply {
+            add(object : AnAction("Refresh", "Reload memory files", AllIcons.Actions.Refresh) {
+                override fun getActionUpdateThread() = ActionUpdateThread.EDT
+                override fun actionPerformed(e: AnActionEvent) {
+                    service.refresh()
+                    showStatus("Refreshed")
+                }
+            })
+            add(object : AnAction("New User Rule", "Create a new user rule file", AllIcons.General.Add) {
+                override fun getActionUpdateThread() = ActionUpdateThread.EDT
+                override fun actionPerformed(e: AnActionEvent) {
+                    val home = System.getProperty("user.home")
+                    val rulesDir = Path.of(home, ".claude", "rules")
+                    createNewRule(MemoryCategory.USER_RULES, rulesDir)
+                }
+            })
+            add(object : AnAction("New Project Rule", "Create a new project rule file", AllIcons.Nodes.Module) {
+                override fun getActionUpdateThread() = ActionUpdateThread.EDT
+                override fun actionPerformed(e: AnActionEvent) {
+                    val projectPath = project.basePath ?: return
+                    val rulesDir = Path.of(projectPath, ".claude", "rules")
+                    createNewRule(MemoryCategory.PROJECT_RULES, rulesDir)
+                }
+            })
+        }
+        val toolbar = ActionManager.getInstance()
+            .createActionToolbar("MemoryViewerToolbar", group, true)
+        toolbar.targetComponent = mainPanel
+        return toolbar
+    }
+
+    private fun showContextMenu(memoryFile: MemoryFile, comp: Component, x: Int, y: Int) {
+        val group = DefaultActionGroup().apply {
+            if (memoryFile.exists) {
+                add(object : AnAction("Open in Editor", "Open this file in the editor", AllIcons.Actions.MenuOpen) {
+                    override fun getActionUpdateThread() = ActionUpdateThread.EDT
+                    override fun actionPerformed(e: AnActionEvent) {
+                        openFile(memoryFile.path)
+                    }
+                })
+                addSeparator()
+                add(object : AnAction("Reveal in Finder", "Show in file manager", AllIcons.Actions.ShowAsTree) {
+                    override fun getActionUpdateThread() = ActionUpdateThread.EDT
+                    override fun actionPerformed(e: AnActionEvent) {
+                        revealInFinder(memoryFile.path)
+                    }
+                })
+                // Allow deletion for rule files only.
+                if (memoryFile.category == MemoryCategory.USER_RULES ||
+                    memoryFile.category == MemoryCategory.PROJECT_RULES
+                ) {
+                    addSeparator()
+                    add(object : AnAction("Delete", "Delete this rule file", AllIcons.General.Remove) {
+                        override fun getActionUpdateThread() = ActionUpdateThread.EDT
+                        override fun actionPerformed(e: AnActionEvent) {
+                            val confirm = Messages.showYesNoDialog(
+                                project,
+                                "Delete '${memoryFile.displayName}'?",
+                                "Delete Rule File",
+                                Messages.getWarningIcon()
+                            )
+                            if (confirm == Messages.YES) {
+                                service.deleteFile(memoryFile.path)
+                                showStatus("Deleted ${memoryFile.displayName}")
+                            }
+                        }
+                    })
+                }
+            } else {
+                add(object : AnAction("Create File", "Create this file", AllIcons.General.Add) {
+                    override fun getActionUpdateThread() = ActionUpdateThread.EDT
+                    override fun actionPerformed(e: AnActionEvent) {
+                        openOrCreateFile(memoryFile)
+                    }
+                })
+            }
+        }
+
+        val popupMenu = ActionManager.getInstance()
+            .createActionPopupMenu("MemoryViewerContext", group)
+        popupMenu.component.show(comp, x, y)
+    }
+
+    private fun openOrCreateFile(memoryFile: MemoryFile) {
+        if (memoryFile.exists) {
+            openFile(memoryFile.path)
+        } else {
+            service.createFile(memoryFile.path)
+            // Wait briefly for file creation, then open.
+            Timer(300) {
+                ApplicationManager.getApplication().invokeLater {
+                    openFile(memoryFile.path)
+                }
+            }.apply {
+                isRepeats = false
+                start()
+            }
+            showStatus("Created ${memoryFile.displayName}")
+        }
+    }
+
+    private fun openFile(path: Path) {
+        val vfs = LocalFileSystem.getInstance()
+        vfs.refreshAndFindFileByNioFile(path)?.let { vf ->
+            FileEditorManager.getInstance(project).openFile(vf, true)
+        }
+    }
+
+    private fun revealInFinder(path: Path) {
+        val file = path.toFile()
+        if (file.exists()) {
+            com.intellij.ide.actions.RevealFileAction.openFile(file)
+        }
+    }
+
+    private fun createNewRule(category: MemoryCategory, baseDir: Path) {
+        val name = Messages.showInputDialog(
+            project,
+            "Enter rule file name (without .md extension):",
+            "New Rule File",
+            AllIcons.General.Add
+        ) ?: return
+
+        if (name.isBlank()) return
+
+        val sanitized = name.trim().replace(Regex("[^a-zA-Z0-9_-]"), "-")
+        val filePath = baseDir.resolve("$sanitized.md")
+
+        service.createFile(filePath, "# $name\n\n")
+        Timer(300) {
+            ApplicationManager.getApplication().invokeLater {
+                openFile(filePath)
+            }
+        }.apply {
+            isRepeats = false
+            start()
+        }
+        showStatus("Created $sanitized.md")
+    }
+
+    private fun loadFiles() {
+        val files = service.getMemoryFiles()
+        rebuildTree(files)
+    }
+
+    private fun rebuildTree(files: List<MemoryFile>) {
+        // Save expanded state.
+        val expandedCategories = mutableSetOf<String>()
+        for (i in 0 until rootNode.childCount) {
+            val child = rootNode.getChildAt(i) as? DefaultMutableTreeNode ?: continue
+            val userObj = child.userObject
+            if (userObj is String && tree.isExpanded(TreePath(arrayOf(rootNode, child)))) {
+                expandedCategories.add(userObj)
+            }
+        }
+
+        rootNode.removeAllChildren()
+
+        if (files.isEmpty()) {
+            treeModel.reload()
+            cardLayout.show(centerPanel, "empty")
+            return
+        }
+
+        // Group by category.
+        val grouped = files.groupBy { it.category }
+
+        for (category in MemoryCategory.entries) {
+            val categoryFiles = grouped[category] ?: emptyList()
+
+            // Always show categories that have files or are expected (User Memory, Project Memory).
+            if (categoryFiles.isEmpty() &&
+                category != MemoryCategory.USER_MEMORY &&
+                category != MemoryCategory.PROJECT_MEMORY
+            ) continue
+
+            val categoryNode = DefaultMutableTreeNode(category.label)
+
+            for (file in categoryFiles) {
+                categoryNode.add(DefaultMutableTreeNode(file))
+            }
+
+            // Add "New rule..." action node for rule categories.
+            if (category == MemoryCategory.USER_RULES) {
+                val home = System.getProperty("user.home")
+                val rulesDir = Path.of(home, ".claude", "rules")
+                categoryNode.add(DefaultMutableTreeNode(NewRuleAction(category, rulesDir)))
+            } else if (category == MemoryCategory.PROJECT_RULES) {
+                val projectPath = project.basePath
+                if (projectPath != null) {
+                    val rulesDir = Path.of(projectPath, ".claude", "rules")
+                    categoryNode.add(DefaultMutableTreeNode(NewRuleAction(category, rulesDir)))
+                }
+            }
+
+            rootNode.add(categoryNode)
+        }
+
+        treeModel.reload()
+
+        // Restore expanded state, or expand all on first load.
+        if (expandedCategories.isEmpty()) {
+            // First load: expand all categories.
+            for (i in 0 until rootNode.childCount) {
+                val child = rootNode.getChildAt(i) as DefaultMutableTreeNode
+                tree.expandPath(TreePath(arrayOf(rootNode, child)))
+            }
+        } else {
+            for (i in 0 until rootNode.childCount) {
+                val child = rootNode.getChildAt(i) as DefaultMutableTreeNode
+                if (child.userObject as? String in expandedCategories) {
+                    tree.expandPath(TreePath(arrayOf(rootNode, child)))
+                }
+            }
+        }
+
+        cardLayout.show(centerPanel, "tree")
+    }
+
+    private fun showStatus(text: String) {
+        statusTimer?.stop()
+        statusLabel.text = text
+        statusLabel.isVisible = true
+        statusTimer = Timer(2000) {
+            statusLabel.isVisible = false
+            mainPanel.revalidate()
+        }
+        statusTimer?.isRepeats = false
+        statusTimer?.start()
+        mainPanel.revalidate()
+    }
+
+    private fun subscribeToChanges() {
+        project.messageBus.connect(parentDisposable)
+            .subscribe(MemoryService.MEMORY_CHANGED_TOPIC,
+                object : MemoryChangedListener {
+                    override fun onMemoryChanged() {
+                        ApplicationManager.getApplication().invokeLater {
+                            loadFiles()
+                        }
+                    }
+                })
+    }
+
+    /**
+     * Marker object for "New rule..." action nodes in the tree.
+     */
+    private data class NewRuleAction(val category: MemoryCategory, val baseDir: Path)
+
+    /**
+     * Custom cell renderer for the memory tree.
+     */
+    private class MemoryTreeCellRenderer : DefaultTreeCellRenderer() {
+        override fun getTreeCellRendererComponent(
+            tree: JTree,
+            value: Any?,
+            sel: Boolean,
+            expanded: Boolean,
+            leaf: Boolean,
+            row: Int,
+            hasFocus: Boolean
+        ): Component {
+            val component = super.getTreeCellRendererComponent(tree, value, sel, expanded, leaf, row, hasFocus)
+
+            val node = value as? DefaultMutableTreeNode ?: return component
+            val userObj = node.userObject
+
+            when (userObj) {
+                is String -> {
+                    // Category header.
+                    text = userObj
+                    icon = AllIcons.Nodes.Folder
+                    font = font.deriveFont(Font.BOLD)
+                }
+                is MemoryFile -> {
+                    if (userObj.exists) {
+                        text = userObj.displayName
+                        icon = AllIcons.FileTypes.Text
+                        font = font.deriveFont(Font.PLAIN)
+                        foreground = if (sel) textSelectionColor else textNonSelectionColor
+                    } else {
+                        text = "${userObj.displayName}  (create)"
+                        icon = AllIcons.FileTypes.Text
+                        font = font.deriveFont(Font.ITALIC)
+                        foreground = if (sel) textSelectionColor else JBColor.GRAY
+                    }
+                }
+                is NewRuleAction -> {
+                    text = "+ New rule..."
+                    icon = AllIcons.General.Add
+                    font = font.deriveFont(Font.ITALIC)
+                    foreground = if (sel) textSelectionColor else JBColor.GRAY
+                }
+            }
+
+            return component
+        }
+    }
+}

--- a/src/main/kotlin/com/example/anthropic/memory/MemoryViewerToolWindowFactory.kt
+++ b/src/main/kotlin/com/example/anthropic/memory/MemoryViewerToolWindowFactory.kt
@@ -1,0 +1,21 @@
+package com.example.anthropic.memory
+
+import com.example.anthropic.settings.AnthropicSettingsState
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.ToolWindow
+import com.intellij.openapi.wm.ToolWindowFactory
+
+class MemoryViewerToolWindowFactory : ToolWindowFactory, DumbAware {
+    override fun shouldBeAvailable(project: Project): Boolean {
+        return service<AnthropicSettingsState>().enableMemoryViewer
+    }
+
+    override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
+        val panel = MemoryViewerPanel(project, toolWindow.disposable)
+        val contentFactory = toolWindow.contentManager.factory
+        val content = contentFactory.createContent(panel.mainPanel, "", false)
+        toolWindow.contentManager.addContent(content)
+    }
+}

--- a/src/main/kotlin/com/example/anthropic/settings/AnthropicSettingsComponent.kt
+++ b/src/main/kotlin/com/example/anthropic/settings/AnthropicSettingsComponent.kt
@@ -24,6 +24,7 @@ class AnthropicSettingsComponent {
     private val enableSessionBrowserCheckbox = JBCheckBox("Session Browser")
     private val enableUsageBarCheckbox = JBCheckBox("Usage Bar")
     private val enableSendToClaudeCheckbox = JBCheckBox("Send to Claude Code")
+    private val enableMemoryViewerCheckbox = JBCheckBox("Memory Viewer")
 
     // Credentials.
     private val useManualTokenCheckbox = JBCheckBox("Use manual access token")
@@ -52,6 +53,7 @@ class AnthropicSettingsComponent {
         enableSessionBrowserCheckbox.isSelected = true
         enableUsageBarCheckbox.isSelected = true
         enableSendToClaudeCheckbox.isSelected = true
+        enableMemoryViewerCheckbox.isSelected = true
 
         // Access token field enabled state depends on checkbox.
         accessTokenField.isEnabled = false
@@ -86,6 +88,7 @@ class AnthropicSettingsComponent {
             .addComponent(enableSessionBrowserCheckbox)
             .addComponent(enableUsageBarCheckbox)
             .addComponent(enableSendToClaudeCheckbox)
+            .addComponent(enableMemoryViewerCheckbox)
             .addVerticalGap(15)
             .addSeparator()
             .addVerticalGap(10)
@@ -215,6 +218,12 @@ class AnthropicSettingsComponent {
         get() = enableSendToClaudeCheckbox.isSelected
         set(value) {
             enableSendToClaudeCheckbox.isSelected = value
+        }
+
+    var enableMemoryViewer: Boolean
+        get() = enableMemoryViewerCheckbox.isSelected
+        set(value) {
+            enableMemoryViewerCheckbox.isSelected = value
         }
 
     // Property accessors.

--- a/src/main/kotlin/com/example/anthropic/settings/AnthropicSettingsConfigurable.kt
+++ b/src/main/kotlin/com/example/anthropic/settings/AnthropicSettingsConfigurable.kt
@@ -28,6 +28,7 @@ class AnthropicSettingsConfigurable : Configurable {
         return c.enableSessionBrowser != settings.enableSessionBrowser ||
                c.enableUsageBar != settings.enableUsageBar ||
                c.enableSendToClaude != settings.enableSendToClaude ||
+               c.enableMemoryViewer != settings.enableMemoryViewer ||
                c.useManualToken != settings.useManualToken ||
                c.accessToken != settings.getSecureAccessToken() ||
                c.refreshInterval != settings.refreshIntervalMinutes ||
@@ -43,11 +44,13 @@ class AnthropicSettingsConfigurable : Configurable {
         val oldAccessToken = settings.getSecureAccessToken()
         val oldEnableUsageBar = settings.enableUsageBar
         val oldEnableSessionBrowser = settings.enableSessionBrowser
+        val oldEnableMemoryViewer = settings.enableMemoryViewer
 
         // Save feature toggles.
         settings.enableSessionBrowser = c.enableSessionBrowser
         settings.enableUsageBar = c.enableUsageBar
         settings.enableSendToClaude = c.enableSendToClaude
+        settings.enableMemoryViewer = c.enableMemoryViewer
 
         // Save credential settings.
         settings.useManualToken = c.useManualToken
@@ -92,6 +95,15 @@ class AnthropicSettingsConfigurable : Configurable {
                 toolWindow?.isAvailable = c.enableSessionBrowser
             }
         }
+
+        // Update Memory Viewer tool window availability across all open projects.
+        if (oldEnableMemoryViewer != c.enableMemoryViewer) {
+            for (project in ProjectManager.getInstance().openProjects) {
+                val toolWindow = ToolWindowManager.getInstance(project)
+                    .getToolWindow("Claude Memory")
+                toolWindow?.isAvailable = c.enableMemoryViewer
+            }
+        }
     }
 
     override fun reset() {
@@ -100,6 +112,7 @@ class AnthropicSettingsConfigurable : Configurable {
         c.enableSessionBrowser = settings.enableSessionBrowser
         c.enableUsageBar = settings.enableUsageBar
         c.enableSendToClaude = settings.enableSendToClaude
+        c.enableMemoryViewer = settings.enableMemoryViewer
         c.useManualToken = settings.useManualToken
         c.accessToken = settings.getSecureAccessToken()
         c.refreshInterval = settings.refreshIntervalMinutes

--- a/src/main/kotlin/com/example/anthropic/settings/AnthropicSettingsState.kt
+++ b/src/main/kotlin/com/example/anthropic/settings/AnthropicSettingsState.kt
@@ -21,6 +21,7 @@ class AnthropicSettingsState : PersistentStateComponent<AnthropicSettingsState.S
         var enableSessionBrowser: Boolean = true,
         var enableUsageBar: Boolean = true,
         var enableSendToClaude: Boolean = true,
+        var enableMemoryViewer: Boolean = true,
         var refreshIntervalMinutes: Int = 5,
         var showNotifications: Boolean = true,
         var notifyAtPercentage: Int = 90,
@@ -59,6 +60,12 @@ class AnthropicSettingsState : PersistentStateComponent<AnthropicSettingsState.S
         get() = myState.enableSendToClaude
         set(value) {
             myState.enableSendToClaude = value
+        }
+
+    var enableMemoryViewer: Boolean
+        get() = myState.enableMemoryViewer
+        set(value) {
+            myState.enableMemoryViewer = value
         }
 
     // Convenience accessors.

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -137,6 +137,18 @@
                 secondary="false"
                 icon="/icons/claudiaSessions.svg"
                 factoryClass="com.example.anthropic.sessions.ui.SessionBrowserToolWindowFactory"/>
+
+        <!-- Memory Viewer tool window on right sidebar -->
+        <toolWindow
+                id="Claude Memory"
+                anchor="right"
+                secondary="false"
+                icon="/icons/claudiaMemory.svg"
+                factoryClass="com.example.anthropic.memory.MemoryViewerToolWindowFactory"/>
+
+        <!-- Project-level service for memory file discovery -->
+        <projectService
+                serviceImplementation="com.example.anthropic.memory.MemoryService"/>
     </extensions>
 
     <actions>

--- a/src/main/resources/icons/claudiaMemory.svg
+++ b/src/main/resources/icons/claudiaMemory.svg
@@ -1,0 +1,6 @@
+<svg width="13" height="13" viewBox="0 0 13 13" xmlns="http://www.w3.org/2000/svg">
+  <rect x="1.5" y="0.5" width="10" height="12" rx="1.5" ry="1.5" fill="none" stroke="#6C707E" stroke-width="1.2"/>
+  <line x1="3.5" y1="3.5" x2="9.5" y2="3.5" stroke="#6C707E" stroke-width="1" stroke-linecap="round"/>
+  <line x1="3.5" y1="6" x2="9.5" y2="6" stroke="#6C707E" stroke-width="1" stroke-linecap="round"/>
+  <line x1="3.5" y1="8.5" x2="7" y2="8.5" stroke="#6C707E" stroke-width="1" stroke-linecap="round"/>
+</svg>

--- a/src/main/resources/icons/claudiaMemory_dark.svg
+++ b/src/main/resources/icons/claudiaMemory_dark.svg
@@ -1,0 +1,6 @@
+<svg width="13" height="13" viewBox="0 0 13 13" xmlns="http://www.w3.org/2000/svg">
+  <rect x="1.5" y="0.5" width="10" height="12" rx="1.5" ry="1.5" fill="none" stroke="#CED0D6" stroke-width="1.2"/>
+  <line x1="3.5" y1="3.5" x2="9.5" y2="3.5" stroke="#CED0D6" stroke-width="1" stroke-linecap="round"/>
+  <line x1="3.5" y1="6" x2="9.5" y2="6" stroke="#CED0D6" stroke-width="1" stroke-linecap="round"/>
+  <line x1="3.5" y1="8.5" x2="7" y2="8.5" stroke="#CED0D6" stroke-width="1" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
## Summary
- New **Claude Memory** tool window on the right sidebar that lists and displays Claude Code memory files (`MEMORY.md` + linked entries under `.claude/projects/<encoded>/memory/`).
- `MemoryService` (project-level) discovers memory files; `MemoryViewerPanel` renders them.
- New **Memory Viewer** feature toggle in *Settings → Tools → Claudia Settings*, default **on**; follows the same pattern as Session Browser (instant enable/disable without IDE restart).
- Light + dark icon variants (`claudiaMemory.svg`, `claudiaMemory_dark.svg`).

## Test plan
- [ ] Tool window **Claude Memory** appears on the right sidebar next to Claude Sessions.
- [ ] Opening a project with `.claude/projects/<encoded>/memory/*.md` files shows them in the panel.
- [ ] Selecting a memory entry renders its content.
- [ ] Disabling *Memory Viewer* in settings hides the tool window immediately; re-enabling brings it back without restart.
- [ ] Projects with no memory files show an empty state, not an error.
- [ ] Regression: Session Browser, Usage Bar, and Send to Claude continue to work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)