### PR TITLE
Add reset time display option to status bar widget

### DIFF
--- a/src/main/kotlin/com/example/anthropic/settings/AnthropicSettingsComponent.kt
+++ b/src/main/kotlin/com/example/anthropic/settings/AnthropicSettingsComponent.kt
@@ -38,6 +38,10 @@ class AnthropicSettingsComponent {
     private val testConnectionButton = JButton("Test Connection")
     private val statusLabel = JBLabel()
 
+    // Reset time display mode.
+    private val showTimeRemainingRadio = JRadioButton("Show time remaining (e.g. 2h 15m)")
+    private val showResetTimeRadio = JRadioButton("Show reset time (e.g. 3:15 PM)")
+
     // All controls in the "Usage Bar Settings" section that should be disabled when the toggle is off.
     private val usageBarSettingsControls = mutableListOf<JComponent>()
 
@@ -52,6 +56,12 @@ class AnthropicSettingsComponent {
         enableSessionBrowserCheckbox.isSelected = true
         enableUsageBarCheckbox.isSelected = true
         enableSendToClaudeCheckbox.isSelected = true
+
+        // Group reset time radio buttons.
+        val resetTimeDisplayGroup = ButtonGroup()
+        resetTimeDisplayGroup.add(showTimeRemainingRadio)
+        resetTimeDisplayGroup.add(showResetTimeRadio)
+        showTimeRemainingRadio.isSelected = true
 
         // Access token field enabled state depends on checkbox.
         accessTokenField.isEnabled = false
@@ -76,7 +86,8 @@ class AnthropicSettingsComponent {
         usageBarSettingsControls.addAll(listOf(
             useManualTokenCheckbox, accessTokenField, autoDiscoveryStatusLabel,
             checkCredentialsButton, refreshIntervalField, showNotificationsCheckbox,
-            notifyAtPercentageField, testConnectionButton
+            notifyAtPercentageField, testConnectionButton,
+            showTimeRemainingRadio, showResetTimeRadio
         ))
 
         // Build the form.
@@ -106,6 +117,10 @@ class AnthropicSettingsComponent {
             .addVerticalGap(10)
             .addComponent(showNotificationsCheckbox)
             .addLabeledComponent("Notify at percentage:", notifyAtPercentageField, 1, false)
+            .addVerticalGap(10)
+            .addComponent(JBLabel("Reset time display:"))
+            .addComponent(showTimeRemainingRadio)
+            .addComponent(showResetTimeRadio)
             .addVerticalGap(15)
             .addComponent(createTestConnectionPanel())
             .addVerticalGap(15)
@@ -248,6 +263,18 @@ class AnthropicSettingsComponent {
         get() = notifyAtPercentageField.text.toIntOrNull() ?: 90
         set(value) {
             notifyAtPercentageField.text = value.toString()
+        }
+
+    var resetTimeDisplayMode: AnthropicSettingsState.ResetTimeDisplayMode
+        get() = if (showResetTimeRadio.isSelected)
+                    AnthropicSettingsState.ResetTimeDisplayMode.RESET_TIME
+                else
+                    AnthropicSettingsState.ResetTimeDisplayMode.TIME_REMAINING
+        set(value) {
+            if (value == AnthropicSettingsState.ResetTimeDisplayMode.RESET_TIME)
+                showResetTimeRadio.isSelected = true
+            else
+                showTimeRemainingRadio.isSelected = true
         }
 
     private fun testConnection() {

--- a/src/main/kotlin/com/example/anthropic/settings/AnthropicSettingsConfigurable.kt
+++ b/src/main/kotlin/com/example/anthropic/settings/AnthropicSettingsConfigurable.kt
@@ -32,7 +32,8 @@ class AnthropicSettingsConfigurable : Configurable {
                c.accessToken != settings.getSecureAccessToken() ||
                c.refreshInterval != settings.refreshIntervalMinutes ||
                c.showNotifications != settings.showNotifications ||
-               c.notifyAtPercentage != settings.notifyAtPercentage
+               c.notifyAtPercentage != settings.notifyAtPercentage ||
+               c.resetTimeDisplayMode != settings.resetTimeDisplayMode
     }
 
     override fun apply() {
@@ -57,6 +58,7 @@ class AnthropicSettingsConfigurable : Configurable {
         settings.refreshIntervalMinutes = c.refreshInterval
         settings.showNotifications = c.showNotifications
         settings.notifyAtPercentage = c.notifyAtPercentage
+        settings.resetTimeDisplayMode = c.resetTimeDisplayMode
 
         // Handle Usage Bar toggle change.
         val usageBarToggleChanged = oldEnableUsageBar != c.enableUsageBar
@@ -105,6 +107,7 @@ class AnthropicSettingsConfigurable : Configurable {
         c.refreshInterval = settings.refreshIntervalMinutes
         c.showNotifications = settings.showNotifications
         c.notifyAtPercentage = settings.notifyAtPercentage
+        c.resetTimeDisplayMode = settings.resetTimeDisplayMode
     }
 
     override fun disposeUIResources() {

--- a/src/main/kotlin/com/example/anthropic/settings/AnthropicSettingsState.kt
+++ b/src/main/kotlin/com/example/anthropic/settings/AnthropicSettingsState.kt
@@ -25,7 +25,8 @@ class AnthropicSettingsState : PersistentStateComponent<AnthropicSettingsState.S
         var showNotifications: Boolean = true,
         var notifyAtPercentage: Int = 90,
         var useManualToken: Boolean = false,  // false = auto-discovery, true = manual token
-        var displayMode: UsageDisplayMode = UsageDisplayMode.FIVE_HOUR  // Which limit to show in status bar
+        var displayMode: UsageDisplayMode = UsageDisplayMode.FIVE_HOUR,  // Which limit to show in status bar
+        var resetTimeDisplayMode: ResetTimeDisplayMode = ResetTimeDisplayMode.TIME_REMAINING
     )
 
     /**
@@ -34,6 +35,14 @@ class AnthropicSettingsState : PersistentStateComponent<AnthropicSettingsState.S
     enum class UsageDisplayMode {
         FIVE_HOUR,
         SEVEN_DAY
+    }
+
+    /**
+     * Whether to show time remaining or absolute reset clock time in the status bar.
+     */
+    enum class ResetTimeDisplayMode {
+        TIME_REMAINING,
+        RESET_TIME
     }
 
     override fun getState(): State = myState
@@ -90,6 +99,12 @@ class AnthropicSettingsState : PersistentStateComponent<AnthropicSettingsState.S
         get() = myState.displayMode
         set(value) {
             myState.displayMode = value
+        }
+
+    var resetTimeDisplayMode: ResetTimeDisplayMode
+        get() = myState.resetTimeDisplayMode
+        set(value) {
+            myState.resetTimeDisplayMode = value
         }
 
     // Secure OAuth access token storage (for manual mode).

--- a/src/main/kotlin/com/example/anthropic/statusbar/AnthropicUsageWidget.kt
+++ b/src/main/kotlin/com/example/anthropic/statusbar/AnthropicUsageWidget.kt
@@ -149,9 +149,14 @@ class AnthropicUsageWidget(private val project: Project) : CustomStatusBarWidget
             }
         }
 
-        // Format: "5h: 35% • 2h 15m" or "7d: 12%".
-        val text = if (timeRemaining != null) {
-            "$label: $percentage% • $timeRemaining"
+        // Format: "5h: 35% • 2h 15m" / "5h: 35% • 3:15 PM" / "7d: 12%".
+        val displayTime = if (settings.resetTimeDisplayMode == AnthropicSettingsState.ResetTimeDisplayMode.RESET_TIME) {
+            data.formattedFiveHourResetsAt
+        } else {
+            timeRemaining
+        }
+        val text = if (displayTime != null) {
+            "$label: $percentage% • $displayTime"
         } else {
             "$label: $percentage%"
         }
@@ -204,6 +209,7 @@ class AnthropicUsageWidget(private val project: Project) : CustomStatusBarWidget
             </table>"""
         }
 
+        val fiveHourResetInfo = data.formattedFiveHourResetsAt?.let { "Resets $it" } ?: ""
         val sevenDayResetInfo = data.formattedSevenDayResetsAt?.let { "Resets $it" } ?: ""
 
         val breakdownHtml = if (data.breakdown.isNotEmpty()) {
@@ -229,6 +235,7 @@ class AnthropicUsageWidget(private val project: Project) : CustomStatusBarWidget
             <br/><br/>
             <b>5-Hour Limit</b>
             ${progressBar(data.fiveHourUtilization, data.fiveHourTimeRemaining)}
+            ${if (fiveHourResetInfo.isNotEmpty()) "<span style='font-size:small'>$fiveHourResetInfo</span>" else ""}
             <br/>
             <b>7-Day Limit</b>
             ${progressBar(data.sevenDayUtilization)}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -20,6 +20,11 @@
 </ul>]]></description>
 
     <change-notes><![CDATA[
+        <h3>1.0.9</h3>
+        <ul>
+            <li><b>Reset time display</b> — usage bar can now show the absolute local clock time when the 5-hour limit resets instead of the time remaining; configurable in Settings → Tools → Claudia Settings</li>
+            <li><b>Reset time in tooltip</b> — hovering the usage bar widget now shows the reset time for both the 5-hour and 7-day limits</li>
+        </ul>
         <h3>1.0.8</h3>
         <ul>
             <li><b>Cross-shell session resume/fork</b> — session resume and fork now work in any configured terminal shell. The plugin detects the shell from <i>Settings → Tools → Terminal → Shell path</i> and uses the correct syntax to clear the inherited CLAUDECODE env var: PowerShell/pwsh (<code>Remove-Item Env:CLAUDECODE</code>), cmd.exe (<code>set "CLAUDECODE="</code>), and POSIX shells like bash/zsh/sh/Git Bash (<code>env -u CLAUDECODE</code>). Fixes the "env is not recognized" error on Windows PowerShell and cmd.</li>


### PR DESCRIPTION
Claude Code's 5-hour usage limit resets on a fixed schedule, and sometimes you just want to know when that is rather than counting down. This adds a simple setting so users can choose to see the reset clock time (e.g. 3:15 PM) directly in the status bar.

# Summary

- Add a "Reset time display" setting to the Usage Bar configuration
- Users can now choose between showing time remaining (e.g. 2h 15m) or the absolute local clock time when the 5-hour limit resets (e.g. 3:15 PM) in the status bar widget
- The tooltip now always shows the reset time for both the 5-hour and 7-day limits, regardless of the display setting

# Screenshots

## Settings page
<img width="777" height="360" alt="image" src="https://github.com/user-attachments/assets/4d7d3f05-9f43-45a2-9de1-40d4196f0e90" />

## Status bar — reset time (24h clock here)
<img width="136" height="34" alt="image" src="https://github.com/user-attachments/assets/a3618608-d8d1-4ad5-8419-4bd45e3c3d95" />

## Tooltip
<img width="383" height="224" alt="image" src="https://github.com/user-attachments/assets/d4681b9c-e3ba-4d2b-87f1-69cc69367e11" />

# Test plan

  - Open Settings → Tools → Claudia Settings → verify two radio buttons appear under "Reset time display"
  - Select "Show reset time" → Apply → status bar changes from 5h: 35% • 2h 15m to 5h: 35% • 3:15 PM
  - Switch back to "Show time remaining" → Apply → reverts correctly
  - Switch to 7-day display mode → status bar shows only 7d: X% regardless of radio selection
  - Hover the widget → tooltip shows reset time for both 5-hour and 7-day sections
  - Disable Usage Bar toggle → verify radio buttons gray out
  - Restart IDE → setting persists